### PR TITLE
Fix an issue where it fails to parse minus values in price

### DIFF
--- a/app/Zaim/Parsers/MoneyParser.php
+++ b/app/Zaim/Parsers/MoneyParser.php
@@ -137,7 +137,7 @@ class MoneyParser extends Parser
      */
     private function parsePrice(string $price): int
     {
-        if (preg_match('/¥([0-9,]+)/', $price, $matches) !== 1) {
+        if (preg_match('/¥([0-9,\-]+)/', $price, $matches) !== 1) {
             throw new ParseException('Could not parse the price.');
         }
 


### PR DESCRIPTION
I made hyphen allowed in parsing prices because price values can be negative in case of a refund or additional discount.